### PR TITLE
Feature/reducers

### DIFF
--- a/client/src/app/reducers/formSlice.ts
+++ b/client/src/app/reducers/formSlice.ts
@@ -20,13 +20,11 @@ const initialState: FormState = {
 };
 
 
-
 export const sendFormAsync = createAsyncThunk(
     'formReducer/sendFormAsync',
     async (form: Inputs) => {
       const res = await axios.post(`http://localhost:3001/product/`);
       return res.data;
-
     },
 );
 
@@ -55,6 +53,9 @@ export const formSlice = createSlice({ // Te creo al reducer, acciones y estados
   },
 });
 
-export const inputs = (state: RootState) => state.formReducer.inputs;
+export const formStatus = (state: RootState) =>
+  state.formReducer.status;
+export const inputs = (state: RootState) =>
+  state.formReducer.inputs;
 
 export default formSlice.reducer;

--- a/client/src/app/reducers/formSlice.ts
+++ b/client/src/app/reducers/formSlice.ts
@@ -55,7 +55,5 @@ export const formSlice = createSlice({ // Te creo al reducer, acciones y estados
 
 export const formStatus = (state: RootState) =>
   state.formReducer.status;
-export const inputs = (state: RootState) =>
-  state.formReducer.inputs;
 
 export default formSlice.reducer;

--- a/client/src/app/reducers/handleProductsSlice.ts
+++ b/client/src/app/reducers/handleProductsSlice.ts
@@ -43,6 +43,9 @@ export const handleProductsSlice = createSlice({
   name: 'products',
   initialState, // Le pasas el estado inicial
   reducers: {
+    resetDeletedByIdStatus: (state) => {
+      state.deleteByIdStatus = 'idle';
+    },
     // Acá metes tus acciones normales de toda la vida
   },
   extraReducers: (builder) => {
@@ -82,8 +85,6 @@ export const handleProductsSlice = createSlice({
   },
 });
 
-export const formStatus = (state: RootState) =>
-  state.formReducer.status;
 export const productsListStatus = (state: RootState) =>
   state.productsReducer.productsListStatus;
 export const deletedProductStatus = (state: RootState) =>
@@ -94,5 +95,7 @@ export const productsList = (state: RootState) =>
   state.productsReducer.productsList;
 export const productDetail = (state: RootState) =>
   state.productsReducer.productById;
+
+export const {resetDeletedByIdStatus} = handleProductsSlice.actions;
 
 export default handleProductsSlice.reducer;

--- a/client/src/app/reducers/handleProductsSlice.ts
+++ b/client/src/app/reducers/handleProductsSlice.ts
@@ -1,6 +1,7 @@
 import {createAsyncThunk, createSlice} from '@reduxjs/toolkit';
 import axios from 'axios';
 import {Products} from '../../types';
+import {RootState} from '../store';
 // import {RootState} from '../store';
 
 const initialState: Products = {/* Acá definanse un Type en types.ts*/
@@ -81,5 +82,17 @@ export const handleProductsSlice = createSlice({
   },
 });
 
+export const formStatus = (state: RootState) =>
+  state.formReducer.status;
+export const productsListStatus = (state: RootState) =>
+  state.productsReducer.productsListStatus;
+export const deletedProductStatus = (state: RootState) =>
+  state.productsReducer.deleteByIdStatus;
+export const productByIdStatus = (state: RootState) =>
+  state.productsReducer.productByIdStatus;
+export const productsList = (state: RootState) =>
+  state.productsReducer.productsList;
+export const productDetail = (state: RootState) =>
+  state.productsReducer.productById;
 
 export default handleProductsSlice.reducer;


### PR DESCRIPTION
Cleaned the code a bit. Removing _inputs_.
Added selectors to easily access store states. To use it, import 'useAppSelector' from hooks.ts

**import {useAppSelector} from '../../app/hooks';**

Then, to get the state you want:

**let state = useAppSelector(storeState);**

Also, to dispatch an action:

**import {useAppDispatch} from '../../app/hooks';**
**const dispatch = useAppDispatch();**   ====>   dispatch(  action  )

I added this states:

_from formSlice.ts:_ we have the key _formStatus_ to get the status of the post request to the backend(_loading_, _failed_, _idle_).

_from handleProductsSlice.ts_ we have a bunch of states:

- _productsListStatus:_ same as _formStatus_ but for GET all products status to the backend(_loading_ ,_failed_, _idle_).
- _deleteByIdStatus:_ a status for the DELETE product by id to the backend(_loading_,_failed_,_idle_, _deleted_ )
- _productByIdStatus:_ also a status for the GET one product to the backend(_loading_,_failed_,_idle_).
- _productsList:_ key to get the current products list from the GET all products.
- _productById:_ key to get the product detail by id from the GET one product.

- Also in _handleProductsSlice.ts_ we have the **resetDeletedByIdStatus** action to dispatch and reset the deleted status from the _deleteByIdStatus_ key.

Example:

**import {useAppSelector, useAppDispatch} from '../../app/hooks';**
**import {productsList, resetDeletedByIdStatus}**

**const dispatch = useAppDispatch()**

**let currentProductsList = useAppSelector(productsList);**    ===>    this saves the products list to currentProductsList

**dispatch( deletedByIdStatus )**   ====>   this reset the status of deleteById to be 'idle', we should use it to close notifications.

